### PR TITLE
Add support for VS2022

### DIFF
--- a/SourceControlFileSelector/SourceControlFileSelector/Misc/TraceLogger.cs
+++ b/SourceControlFileSelector/SourceControlFileSelector/Misc/TraceLogger.cs
@@ -3,6 +3,7 @@
 //// --------------------------------------------------------------------------------------------------------------------
 
 using EnvDTE;
+using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using System;
 
@@ -13,7 +14,7 @@ namespace SourceControlFileSelector.Misc
     {
         #region Private Fields
 
-        private DTE dte;
+        private DTE2 dte2;
         private OutputWindowPane outputPane;
 
         #endregion Private Fields
@@ -22,9 +23,9 @@ namespace SourceControlFileSelector.Misc
 
         /// <summary>The trace logger.</summary>
         /// <param name="dte"></param>
-        public TraceLogger(DTE dte)
+        public TraceLogger(DTE2 dte2)
         {
-            this.dte = dte;
+            this.dte2 = dte2;
             outputPane = GetOutputPane();
 
             outputPane.Activate();
@@ -58,8 +59,7 @@ namespace SourceControlFileSelector.Misc
 
             if (outputPane == null)
             {
-                var window = dte.Windows.Item(Constants.vsWindowKindOutput);
-                var outputWindow = (OutputWindow)window.Object;
+                var outputWindow = dte2.ToolWindows.OutputWindow;
                 outputPane = outputWindow.OutputWindowPanes.Add("Source control file selector");
             }
 

--- a/SourceControlFileSelector/SourceControlFileSelector/SourceControlFileSelector.csproj
+++ b/SourceControlFileSelector/SourceControlFileSelector/SourceControlFileSelector.csproj
@@ -91,21 +91,12 @@
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="EnvDTE100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
     <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="EnvDTE90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.TeamFoundation.Client">
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26228\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>

--- a/SourceControlFileSelector/SourceControlFileSelector/SourceControlFileSelectorCommand.cs
+++ b/SourceControlFileSelector/SourceControlFileSelector/SourceControlFileSelectorCommand.cs
@@ -3,6 +3,7 @@
 //// --------------------------------------------------------------------------------------------------------------------
 
 using EnvDTE;
+using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using SourceControlFileSelector.Misc;
 using SourceControlFileSelector.tfsAccess;
@@ -65,9 +66,7 @@ namespace SourceControlFileSelector
 
         #region Private Properties
 
-        private static DTE dte { get; set; }
-
-        private static EnvDTE80.DTE2 dte2 { get; set; }
+        private static DTE2 dte2 { get; set; }
 
         /// <summary>Gets the service provider from the owner package.</summary>
         private IAsyncServiceProvider ServiceProvider
@@ -93,8 +92,7 @@ namespace SourceControlFileSelector
             OleMenuCommandService commandService = await package.GetServiceAsync((typeof(IMenuCommandService))) as OleMenuCommandService;
             Instance = new SourceControlFileSelectorCommand(package, commandService);
 
-            dte = await package.GetServiceAsync(typeof(DTE)) as DTE;
-            dte2 = await package.GetServiceAsync(typeof(DTE)) as EnvDTE80.DTE2;
+            dte2 = await package.GetServiceAsync(typeof(DTE)) as DTE2;
         }
 
         #endregion Public Methods
@@ -111,7 +109,7 @@ namespace SourceControlFileSelector
         private void Execute(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var logger = new TraceLogger(dte);
+            var logger = new TraceLogger(dte2);
 
             if (dte2?.ActiveWindow != null && dte2?.ActiveWindow == dte2?.ActiveDocument?.ActiveWindow)
             {

--- a/SourceControlFileSelector/SourceControlFileSelector/source.extension.vsixmanifest
+++ b/SourceControlFileSelector/SourceControlFileSelector/source.extension.vsixmanifest
@@ -10,9 +10,12 @@
         <Tags >SourceControl</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)" />
-        <InstallationTarget Version="[15.0, 17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0, 17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 18.0)">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
1. Replace EnvDTE.Windows with EnvDTE80.ToolWindows as the former is no
   longer working well in 64-bit

2. Remove Microsoft.VisualStudio.CommandBars unused reference

3. Update HintPath for Microsoft.TeamFoundation.Client to VS2022